### PR TITLE
Compatibility with MacOS bash (3.2.57)

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -4,4 +4,4 @@
 source "${MISE_PLUGIN_PATH-${0%/*}/..}/utils.sh"
 
 # shellcheck disable=SC1090
-source <(sops_env)
+eval "$(sops_env)"


### PR DESCRIPTION
It turns out `source <(command)` does not work correctly on MacOS Sonoma's bash.

```sh
bash-3.2$ source <(echo "export HELLO=world")
bash-3.2$ echo $HELLO

bash-3.2$
```

Changing `source` to `eval` fixes the problem.  Given all output from the `sops_env` function is escaped, I think this is equally safe.

```sh
bash-3.2$ eval $(echo "export HELLO=world")
bash-3.2$ echo $HELLO
world
bash-3.2$
```